### PR TITLE
Use path.join() and process.cwd()

### DIFF
--- a/pages/api/sizeCheckAPI/[hello].ts
+++ b/pages/api/sizeCheckAPI/[hello].ts
@@ -30,9 +30,9 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     //     "https://minimal-public-asset-not-found.vercel.app/staticAssets/next.svg";
     //
 
-    // Based on the output source in vercel deployment this is the file path I would expect to work
-    finalFontFilePath = "staticAssets/Roboto-Regular.ttf";
-    finalImageFilePath = "staticAssets/next.svg";
+    // Using path.join() based on https://vercel.com/guides/how-can-i-use-files-in-serverless-functions
+    finalFontFilePath = path.join(process.cwd(), "public", "staticAssets", "Roboto-Regular.ttf");
+    finalImageFilePath = path.join(process.cwd(), "public", "staticAssets",  "next.svg");
   }
   try {
     var stats = fs.statSync(finalFontFilePath);


### PR DESCRIPTION
Proposing this change to solve `ENOENT` problem discussed in https://github.com/vercel/community/discussions/1240